### PR TITLE
chore(renovate): disable digest-pinning for the Dockerfile manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,11 @@
       "description": "Let major updates soak before automerge",
       "matchUpdateTypes": ["major"],
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Don't digest-pin the Dockerfile's floating tags. `golang` is tracked at minor granularity via ARG GO_VERSION (the cross-manager 'go version' group + check-go-alignment); pinning a digest onto that ARG line collides with the version bump (one silently dropped) and risks renovate#18022 ARG-folding. `docker/dockerfile:1` is the recommended floating BuildKit frontend. The builder is a throwaway stage (final image is scratch), so a digest pin adds no runtime-security value.",
+      "matchManagers": ["dockerfile"],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
## What
Scope `pinDigests: false` to the `dockerfile` manager in `renovate.json`.

## Why
`config:best-practices` enables `docker:pinDigests`, which (verified via `renovate --platform=local --dry-run=lookup`) generates `pinDigest` updates for both Dockerfile deps on a `renovate/pin-dependencies` branch:
- **`golang`** — tracked at minor granularity via `ARG GO_VERSION=1.26` (the cross-manager `go version` group + `check-go-alignment`). Pinning a digest folds `@sha256:…` onto that ARG line, which collides with the version bump (one update silently dropped) and risks the renovate#18022 ARG-folding trap.
- **`# syntax=docker/dockerfile:1`** — the recommended *floating* BuildKit frontend tag; pinning it defeats its auto-update.

The builder is a throwaway stage (final image is `scratch`), so a builder-base digest pin adds no runtime-security value.

## Verification (by effect, not just config-valid)
- `renovate-config-validator`: clean
- `isPinDigest` updates: **2 → 0**
- `renovate/pin-dependencies` branch refs: **0**

## Test plan
- [x] `make renovate-validate` clean
- [x] local extract confirms all 4 managers resolve (gomod/dockerfile/github-actions/mise); Dockerfile `ARG GO_VERSION` tracked as depName `golang`
- [ ] CI `ci-pass` green